### PR TITLE
Consistent args

### DIFF
--- a/R/calc_Eref_CMD.R
+++ b/R/calc_Eref_CMD.R
@@ -40,10 +40,10 @@ calc_CMD <- function(Eref, PPT) {
 
 #' PROGRAM I From Hargreaves 1985
 #' @param d numeric. Julian day of the year (January 1 = 1, December 31 = 365).
-#' @param tmean mean temperature for that month
+#' @param tm numeric. Monthly mean temperature for the corresponding month.
 #' @template latitude
 #' @return numeric. Extraterrestrial radiation estimation in mm/day
-calc_S0_I <- function(d, tmean, latitude) {
+calc_S0_I <- function(d, tm, latitude) {
   # BASIC COMPUTER PROGRAM FOR ESTIMATING DAILY RA VALUES
   # D=JULIAN DAY (JANUARY 1=1)
   # DEC=DECLINATION OF THE SUN IN RADIANS
@@ -63,17 +63,17 @@ calc_S0_I <- function(d, tmean, latitude) {
   DL <- OM / 0.1309
   RAL <- 120 * (DL * sin(XLR) * sin(DEC) + 7.639 * cos(XLR) * cos(DEC) * sin(OM)) / ES
   # CALCULATE THE EXTRATERRESTRIAL RADIATION IN MM/DAY
-  RA <- RAL * 10 / (595.9 - 0.55 * tmean)
+  RA <- RAL * 10 / (595.9 - 0.55 * tm)
 
   return(RA)
 }
 
 #' PROGRAM II From Hargreaves 1985
 #' @template m
-#' @param tmean mean temperature for that month
+#' @template tm
 #' @template latitude
 #' @return numeric. Extraterrestrial radiation estimation in mm/day
-calc_S0_II <- function(m, tmean, latitude) {
+calc_S0_II <- function(m, tm, latitude) {
   # BASIC COMPUTER PROGRAM FOR ESTIMATING MONTHLY RA VALUES
   # DEC=DECLINATION OF THE SUN IN RADIANS
   # ES=MEAN MONTHLY DISTANCE OF THE SUN TO THE EARTH DIVIDED BY THE MEAN ANNUAL DISTANCE
@@ -96,7 +96,7 @@ calc_S0_II <- function(m, tmean, latitude) {
   # CALCULATE THE DAILY EXTRATERRESTRIAL RADIATION IN LANGLEYS/DAY
   RAL <- 916.732 * (OM * sin(XLR) * sin(DEC) + cos(XLR) * cos(DEC) * sin(OM)) / ES
   # CALCULATE THE EXTRATERRESTRIAL RADIATION IN MM/DAY
-  RA <- RAL * 10 / (595.9 - 0.55 * tmean)
+  RA <- RAL * 10 / (595.9 - 0.55 * tm)
 
   return(RA)
 }

--- a/R/calc_Eref_CMD.R
+++ b/R/calc_Eref_CMD.R
@@ -1,12 +1,12 @@
 #' Calculate Extreme Minimum Temperature (EMT)
 #' @template m
-#' @param tmin monthly mean minimum air temperature
-#' @param tmax monthly mean maximum air temperature
+#' @template tmmin
+#' @template tmmax
 #' @template latitude
 #' @return numeric. Reference evaporation (Eref)
-calc_Eref <- function(m, tmin, tmax, latitude) {
-  Eref <- numeric(length(tmax))
-  tmean <- (tmax + tmin) / 2
+calc_Eref <- function(m, tmmin, tmmax, latitude) {
+  Eref <- numeric(length(tmmax))
+  tmean <- (tmmax + tmmin) / 2
   i <- which(tmean >= 0)
   day_month <- c(31, 28.25, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
   day_julian <- c(15, 45, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349)
@@ -15,10 +15,10 @@ calc_Eref <- function(m, tmin, tmax, latitude) {
   # Probably missing
   Eref[i] <- 0.0023 * day_month[m] *
     calc_S0_I(day_julian[m], tmean[i], latitude[i]) *
-    (tmean[i] + 17.8) * sqrt(tmax[i] - tmin[i]) *
+    (tmean[i] + 17.8) * sqrt(tmmax[i] - tmmin[i]) *
     (1.18 - 0.0065 * latitude[i])
 
-  Eref[is.na(tmax)] <- tmax[is.na(tmax)] ## use tmax[is.na(tmax)] to respect NA type
+  Eref[is.na(tmmax)] <- tmmax[is.na(tmmax)] ## use tmmax[is.na(tmmax)] to respect NA type
   
   return(Eref)
 }

--- a/R/calc_NFFD.R
+++ b/R/calc_NFFD.R
@@ -1,7 +1,7 @@
 #' Calculate Number of Frost Free Days (NFFD)
 #'
 #' @template m
-#' @param tm min temperature for that month
+#' @template tmin
 #'
 #' @return numeric. Number of Frost Free Days
 #'
@@ -9,9 +9,9 @@
 #' \dontrun{
 #' climr:::calc_NFFD(3, 2.05)
 #' }
-calc_NFFD <- function(m, tm) {
+calc_NFFD <- function(m, tmin) {
   if (FALSE) {
     a <- T0 <- b <- NULL
   }
-  param[["NFFD"]][m, a / (1 + exp(-(tm - T0) / b))]
+  param[["NFFD"]][m, a / (1 + exp(-(tmin - T0) / b))]
 }

--- a/R/calc_PAS.R
+++ b/R/calc_PAS.R
@@ -10,10 +10,10 @@
 #' \dontrun{
 #' climr:::calc_PAS(4, 2, 600)
 #' }
-calc_PAS <- function(m, tmin, ppt) {
+calc_PAS <- function(m, tmin, PPT) {
   if (FALSE) {
     T0 <- a <- b <- NULL
   }
 
-  param[["PAS"]][m, ppt * a / (1 + exp(-(tmin - T0) / b))]
+  param[["PAS"]][m, PPT * a / (1 + exp(-(tmin - T0) / b))]
 }

--- a/R/calc_PAS.R
+++ b/R/calc_PAS.R
@@ -1,7 +1,7 @@
 #' Calculate Precipitation As Snow (PAS)
 #'
 #' @template m
-#' @param tm min temperature for that month
+#' @template tmin
 #' @template PPT
 #'
 #' @return numeric. Precipitation As Snow
@@ -10,10 +10,10 @@
 #' \dontrun{
 #' climr:::calc_PAS(4, 2, 600)
 #' }
-calc_PAS <- function(m, tm, ppt) {
+calc_PAS <- function(m, tmin, ppt) {
   if (FALSE) {
     T0 <- a <- b <- NULL
   }
 
-  param[["PAS"]][m, ppt * a / (1 + exp(-(tm - T0) / b))]
+  param[["PAS"]][m, ppt * a / (1 + exp(-(tmin - T0) / b))]
 }

--- a/R/calc_RH.R
+++ b/R/calc_RH.R
@@ -1,17 +1,17 @@
 #' Calculate Relative Humidity (RH)
 #'
-#' @param tmin monthly mean minimum air temperature
-#' @param tmax monthly mean maximum air temperature
+#' @template tmmin
+#' @template tmmax
 #'
 #' @return numeric. Relative Humidity
 #'
 #' @examples
 #' \dontrun{
-#' climr:::calc_RH(tmin = 10, tmax = 40)
+#' climr:::calc_RH(tmmin = 10, tmmax = 40)
 #' }
-calc_RH <- function(tmin, tmax) {
-  es_tmin <- calc_SVP(tmin)
-  es_tmax <- calc_SVP(tmax)
+calc_RH <- function(tmmin, tmmax) {
+  es_tmin <- calc_SVP(tmmin)
+  es_tmax <- calc_SVP(tmmax)
   es_avg <- (es_tmin + es_tmax) / 2
   return(100 * es_tmin / es_avg)
 }
@@ -21,14 +21,14 @@ calc_RH <- function(tmin, tmax) {
 #' Based on simplified Penman - Monteith method from Hogg (1997)
 #'
 #' @param tave numeric. Monthly average minimum air temperature.
-#' @param tmin monthly mean minimum air temperature
-#' @param tmax monthly mean maximum air temperature
+#' @template tmmin
+#' @template tmmax
 #' @param alt numeric. Altitude in m.
 #'
 #' @references Hogg, E.H. (1997). Temporal scaling of moisture and the forest-grassland boundary in western Canada. Agricultural and Forest Meteorology, Research on Forest Environmental Influences in a Changing World, 84, 115–122.
 #' @importFrom data.table fifelse
-calc_PET <- function(tave, tmin, tmax, alt) {
-  D <- 0.5 * (.calc_SVP(tmax) - .calc_SVP(tmin)) - .calc_SVP(tmin - 2.5)
+calc_PET <- function(tave, tmmin, tmmax, alt) {
+  D <- 0.5 * (.calc_SVP(tmmax) - .calc_SVP(tmmin)) - .calc_SVP(tmmin - 2.5)
   pet <- fifelse(
     tave > 10, 93 * D * exp(alt / 9300),
     fifelse(tave > -5, (6.2 * tave + 31) * D * exp(alt / 9300), 0)

--- a/man-roxygen/tmin.R
+++ b/man-roxygen/tmin.R
@@ -1,0 +1,1 @@
+#' @param tmin numeric. Minimum temperature for the `m` month.

--- a/man-roxygen/tmmax.R
+++ b/man-roxygen/tmmax.R
@@ -1,0 +1,1 @@
+#' @param tmmax numeric. Monthly mean maximum air temperature.

--- a/man-roxygen/tmmin.R
+++ b/man-roxygen/tmmin.R
@@ -1,0 +1,1 @@
+#' @param tmmin numeric. Monthly mean minimum air temperature.

--- a/man/calc_Eref.Rd
+++ b/man/calc_Eref.Rd
@@ -4,14 +4,14 @@
 \alias{calc_Eref}
 \title{Calculate Extreme Minimum Temperature (EMT)}
 \usage{
-calc_Eref(m, tmin, tmax, latitude)
+calc_Eref(m, tmmin, tmmax, latitude)
 }
 \arguments{
 \item{m}{integer. Month of the year.}
 
-\item{tmin}{monthly mean minimum air temperature}
+\item{tmmin}{numeric. Monthly mean minimum air temperature.}
 
-\item{tmax}{monthly mean maximum air temperature}
+\item{tmmax}{numeric. Monthly mean maximum air temperature.}
 
 \item{latitude}{numeric. Point latitudes.}
 }

--- a/man/calc_NFFD.Rd
+++ b/man/calc_NFFD.Rd
@@ -4,12 +4,12 @@
 \alias{calc_NFFD}
 \title{Calculate Number of Frost Free Days (NFFD)}
 \usage{
-calc_NFFD(m, tm)
+calc_NFFD(m, tmin)
 }
 \arguments{
 \item{m}{integer. Month of the year.}
 
-\item{tm}{min temperature for that month}
+\item{tmin}{numeric. Minimum temperature for the \code{m} month.}
 }
 \value{
 numeric. Number of Frost Free Days

--- a/man/calc_PAS.Rd
+++ b/man/calc_PAS.Rd
@@ -4,14 +4,14 @@
 \alias{calc_PAS}
 \title{Calculate Precipitation As Snow (PAS)}
 \usage{
-calc_PAS(m, tm, ppt)
+calc_PAS(m, tmin, PPT)
 }
 \arguments{
 \item{m}{integer. Month of the year.}
 
-\item{tm}{min temperature for that month}
+\item{tmin}{numeric. Minimum temperature for the \code{m} month.}
 
-\item{ppt}{numeric. Precipitation in mm.}
+\item{PPT}{numeric. Precipitation in mm.}
 }
 \value{
 numeric. Precipitation As Snow

--- a/man/calc_PET.Rd
+++ b/man/calc_PET.Rd
@@ -4,14 +4,14 @@
 \alias{calc_PET}
 \title{Calculate Potential Evapotranspiration}
 \usage{
-calc_PET(tave, tmin, tmax, alt)
+calc_PET(tave, tmmin, tmmax, alt)
 }
 \arguments{
 \item{tave}{numeric. Monthly average minimum air temperature.}
 
-\item{tmin}{monthly mean minimum air temperature}
+\item{tmmin}{numeric. Monthly mean minimum air temperature.}
 
-\item{tmax}{monthly mean maximum air temperature}
+\item{tmmax}{numeric. Monthly mean maximum air temperature.}
 
 \item{alt}{numeric. Altitude in m.}
 }

--- a/man/calc_RH.Rd
+++ b/man/calc_RH.Rd
@@ -4,12 +4,12 @@
 \alias{calc_RH}
 \title{Calculate Relative Humidity (RH)}
 \usage{
-calc_RH(tmin, tmax)
+calc_RH(tmmin, tmmax)
 }
 \arguments{
-\item{tmin}{monthly mean minimum air temperature}
+\item{tmmin}{numeric. Monthly mean minimum air temperature.}
 
-\item{tmax}{monthly mean maximum air temperature}
+\item{tmmax}{numeric. Monthly mean maximum air temperature.}
 }
 \value{
 numeric. Relative Humidity
@@ -19,6 +19,6 @@ Calculate Relative Humidity (RH)
 }
 \examples{
 \dontrun{
-climr:::calc_RH(tmin = 10, tmax = 40)
+climr:::calc_RH(tmmin = 10, tmmax = 40)
 }
 }

--- a/man/calc_S0_I.Rd
+++ b/man/calc_S0_I.Rd
@@ -4,12 +4,12 @@
 \alias{calc_S0_I}
 \title{PROGRAM I From Hargreaves 1985}
 \usage{
-calc_S0_I(d, tmean, latitude)
+calc_S0_I(d, tm, latitude)
 }
 \arguments{
 \item{d}{numeric. Julian day of the year (January 1 = 1, December 31 = 365).}
 
-\item{tmean}{mean temperature for that month}
+\item{tm}{numeric. Monthly mean temperature for the corresponding month.}
 
 \item{latitude}{numeric. Point latitudes.}
 }

--- a/man/calc_S0_II.Rd
+++ b/man/calc_S0_II.Rd
@@ -4,12 +4,12 @@
 \alias{calc_S0_II}
 \title{PROGRAM II From Hargreaves 1985}
 \usage{
-calc_S0_II(m, tmean, latitude)
+calc_S0_II(m, tm, latitude)
 }
 \arguments{
 \item{m}{integer. Month of the year.}
 
-\item{tmean}{mean temperature for that month}
+\item{tm}{numeric. Monthly mean temperature for the \code{m} month.}
 
 \item{latitude}{numeric. Point latitudes.}
 }

--- a/tests/testthat/test-calcfuns.R
+++ b/tests/testthat/test-calcfuns.R
@@ -38,9 +38,9 @@ test_that("calc_* functions work", {
   expect_identical(climr:::calc_PAS(4, NA, 600), NA_real_)
   expect_identical(climr:::calc_PAS(4, 2, NA_real_), NA_real_)
 
-  expect_identical(round(climr:::calc_RH(tmin = 10, tmax = 40), 4), 28.5378)
-  expect_identical(climr:::calc_RH(tmin = NA, tmax = 40), NA_real_)
-  expect_identical(climr:::calc_RH(tmin = 10, tmax = NA), NA_real_)
+  expect_identical(round(climr:::calc_RH(tmmin = 10, tmmax = 40), 4), 28.5378)
+  expect_identical(climr:::calc_RH(tmmin = NA, tmmax = 40), NA_real_)
+  expect_identical(climr:::calc_RH(tmmin = 10, tmmax = NA), NA_real_)
 })
 
 


### PR DESCRIPTION
When arguments mean the same across functions, we should use the same argument name and documentation @template. This makes debugging and package maintenance easier and allows for more streamlined code.

I have noticed some of the `calc_*` functions seem to have identical input arguments with different names (e.g., `tmean` and some instances of `tm`), or arguments that are different but that share the same name (e.g., `tm` was used for average and minimum temperatures in different functions).

I've tried to fix this, but a very careful review is needed.