### PR TITLE
install fails due to stinepack being importedFrom, but not in Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     RPostgres,
     terra,
     sf,
+    stinepack,
     uuid
 Suggests: 
     ggplot2,
@@ -42,7 +43,6 @@ Suggests:
     plotly,
     rmarkdown,
     remotes,
-    stinepack,
     testthat (>= 3.0.0),
     utils,
     withr


### PR DESCRIPTION
```
> remotes::install_github("bcgov/climr@devl")
Using GitHub PAT from the git credential store.
Downloading GitHub repo bcgov/climr@devl
── R CMD build ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file 'C:\Users\emcintir\AppData\Local\Temp\RtmpeOWOi7\remotes6594c6f47d0\bcgov-climr-67ba167/DESCRIPTION'
─  preparing 'climr': (1.7s)
✔  checking DESCRIPTION meta-information
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building 'climr_0.0.4.1.tar.gz'
   
Installing package into ‘C:/Users/emcintir/AppData/Local/R/win-library/4.3’
(as ‘lib’ is unspecified)
* installing *source* package 'climr' ...
** using staged installation
** R
** data
*** moving datasets to lazyload DB
** inst
** byte-compile and prepare package for lazy loading
Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
  there is no package called 'stinepack'
Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted
ERROR: lazy loading failed for package 'climr'
* removing 'C:/Users/emcintir/AppData/Local/R/win-library/4.3/climr'
```